### PR TITLE
[#72, #73] Move over to `Dialog` and add some css to disable buttons

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,5 +1,5 @@
 .effective-transferral.transfer-app {
-  height: auto !important;
+  height: auto;
 }
 
 .effective-transferral.transfer-app .instruction {
@@ -37,4 +37,11 @@
 .effective-transferral.transfer-app .specifics {
   display: flex;
   gap: 0.4em;
+}
+
+.effective-transferral.transfer-app form:not(:has(.effect input[data-type=target]:checked)) .buttons [data-type=TARGET],
+.effective-transferral.transfer-app form:not(:has(.effect input[data-type=self]:checked)) .buttons [data-type=SELF],
+.effective-transferral.transfer-app form:not(:has(.effect input[data-type]:checked)) .buttons [data-type=ALL] {
+  pointer-events: none;
+  color: gray;
 }

--- a/templates/TransferApp.hbs
+++ b/templates/TransferApp.hbs
@@ -22,19 +22,19 @@
   </div>
   <div class="buttons">
     {{#if self}}
-    <button type="submit" data-type="ALL">
+    <button type="button" data-type="ALL">
       <i class="fa-solid fa-check"></i> {{localize "ET.Dialog.Button.Apply"}}
     </button>
     <div class="specifics">
-      <button type="submit" data-type="SELF">
+      <button type="button" data-type="SELF">
         <i class="fa-solid fa-user"></i> {{localize "ET.Dialog.Button.Self"}}
       </button>
-      <button type="submit" data-type="TARGET">
+      <button type="button" data-type="TARGET">
         <i class="fa-solid fa-bullseye"></i> {{localize "ET.Dialog.Button.Targets"}}
       </button>
     </div>
     {{else}}
-    <button type="submit" data-type="TARGET">
+    <button type="button" data-type="TARGET">
       <i class="fa-solid fa-bullseye"></i> {{localize "ET.Dialog.Button.Targets"}}
     </button>
     {{/if}}


### PR DESCRIPTION
Closes #72.
Closes #73.

Using the `:has` selector is all gucci now that firefox has caught up. :-)